### PR TITLE
Boss Wave Buffs

### DIFF
--- a/scripts/population/mvm_snowpine_rc4_fix1_adv_shivering_slumber.pop
+++ b/scripts/population/mvm_snowpine_rc4_fix1_adv_shivering_slumber.pop
@@ -491,6 +491,10 @@ ShiveringSlumber
 			MaxVisionRange 2000
 			SpawnTemplate mercury_logic
 			SpawnTemplate boss_mercury_death
+			WeaponResist
+			{
+				"TF_WEAPON_MINIGUN" 0.7
+			}
 			ItemAttributes
 			{
 				ItemName "upgradeable tf_weapon_grenadelauncher"
@@ -556,7 +560,7 @@ ShiveringSlumber
 					}
 					FireInput
 					{
-						Delay 12
+						Delay 9
 						Target MercuryLaunchers
 						Action PickRandomShuffle
 						Repeats 999
@@ -578,7 +582,7 @@ ShiveringSlumber
 					{
 						Target MercuryLaunchers
 						Action PickRandomShuffle
-						Delay 12
+						Delay 9
 						Repeats 999
 						Cooldown 15
 					}
@@ -607,7 +611,7 @@ ShiveringSlumber
 					{
 						Target MercuryLaunchers
 						Action PickRandomShuffle
-						Delay 12
+						Delay 9
 						Cooldown 15
 						Repeats 999
 					}
@@ -646,7 +650,7 @@ ShiveringSlumber
 					{
 						Target MercuryLaunchers
 						Action PickRandomShuffle
-						Delay 12
+						Delay 9
 						Cooldown 15
 						Repeats 999
 					}
@@ -1726,7 +1730,7 @@ ShiveringSlumber
 			MaxActive 8
 			Where spawnbot
 			WaitBeforeStarting 0
-			WaitBetweenSpawns 7.5
+			WaitBetweenSpawns 7
 			StartDisabled 1
 			Support 1
 			TotalCurrency 300
@@ -1767,7 +1771,7 @@ ShiveringSlumber
 			MaxActive 8
 			Where flankers
 			WaitBeforeStarting 0
-			WaitBetweenSpawns 7.5
+			WaitBetweenSpawns 7
 			TotalCurrency 300
 			Support 1
 			StartDisabled 1
@@ -1807,7 +1811,7 @@ ShiveringSlumber
 			MaxActive 2
 			Where spawnbot_boss
 			WaitBeforeStarting 0
-			WaitBetweenSpawns 20
+			WaitBetweenSpawns 18
 			Support 1
 			TotalCurrency 200
 			StartDisabled 1


### PR DESCRIPTION
Common bots spawn have .5 second faster spawns.
Giants spawn 2 seconds faster.

Major Mercury spawns 3 less seconds between launchers and has 30% minigun resistance.